### PR TITLE
Resolve bug Countdown Timer Not Starting on Initial Load

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -48,7 +48,6 @@ export default function App() {
   const getNewQuote = useCallback(() => {
     setCount(COUNTDOWN_DURATION);
     fetchNewQuote(setQuote, setLoading);
-    startCountDown();
     setColor(randomColor());
   }, []);
 
@@ -70,7 +69,7 @@ export default function App() {
     }
   }, [getNewQuote]);
 
-  // Handle updating localStorage and generating new color when quote changes
+  // Handle updating localStorage
   useEffect(() => {
     if (quote) {
       if (typeof window !== 'undefined') {
@@ -83,6 +82,10 @@ export default function App() {
     if (count === null && intervalRef) {
       clearInterval(intervalRef.current);
       intervalRef.current = null;
+    }
+
+    if (count === COUNTDOWN_DURATION) {
+      startCountDown();
     }
   }, [count]);
 


### PR DESCRIPTION
**Description:**
- This pull request addresses the issue where the countdown timer did not start on the initial load after requesting the first quote. The countdown timer is now correctly initialized and starts decrementing immediately after the first quote is fetched.

### Changes Made
- Moved the `startCountDown` function inside a `useEffect` hook that triggers on every `count` update.
- Added logic to check if `count === COUNTDOWN_DURATION` before starting the countdown, ensuring the timer starts as expected on the first load.

**Testing:**
- Verified that the countdown timer starts on the first load after fetching the initial quote.
- Tested across multiple browser sessions to confirm consistent behavior.

**Related Issue:**
- Closes #12 