### PR TITLE
Improve Color Readability and Ensure Color Changes on New Quote Request

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -2,6 +2,7 @@ export const API_BASE_URL = 'https://api.api-ninjas.com/v1/quotes';
 export const LOCAL_STORAGE_QUOTES_KEY = 'myQuote';
 export const COUNTDOWN_DURATION = 5;
 export const ERROR_COUNTDOWN_DURATION = 3;
+export const COLOR_LUMINOSITY = { luminosity: 'dark' };
 
 // Messages
 export const API_ERROR_MESSAGE =

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -4,7 +4,11 @@ import React, { useEffect, useState } from 'react';
 
 import HandleErrorMessages from '@/components/HandleErrorMessages';
 import Loading from '@/components/Loading';
-import { API_ERROR_MESSAGE, LOCAL_STORAGE_QUOTES_KEY } from '@/constants/index';
+import {
+  API_ERROR_MESSAGE,
+  COLOR_LUMINOSITY,
+  LOCAL_STORAGE_QUOTES_KEY,
+} from '@/constants/index';
 import useErrorCountdown from '@/hooks/useErrorCountdown';
 
 import styles from '@/styles/index.module.css';
@@ -23,6 +27,7 @@ export default function App() {
 
   const getNewQuote = async () => {
     try {
+      setColor(randomColor(COLOR_LUMINOSITY));
       setLoading(true);
       triggerSuccessCountdown();
       const response = await axios.get('/api/proxy');
@@ -37,12 +42,12 @@ export default function App() {
 
   // Retrieve from localStorage and setQuote if storedQuote, otherwise requests new quote.
   useEffect(() => {
-    setColor(randomColor());
     // Make sure this code only runs on the client
     if (typeof window !== 'undefined') {
       const storedQuote = localStorage.getItem(LOCAL_STORAGE_QUOTES_KEY);
 
       if (storedQuote) {
+        setColor(randomColor(COLOR_LUMINOSITY));
         setQuote(JSON.parse(storedQuote));
         return;
       }


### PR DESCRIPTION
**Description:**
This pull request addresses the issue where:
1. The colors generated for the quote text and button were sometimes too bright, making them hard to read on a light background.
2. The color did not change with each new quote request.

This update improves the color generation by ensuring good enough contrast and dynamically updating the color with each new quote request.

### Changes Made:

- **Color Luminosity Control:**
  - Introduced a constant `COLOR_LUMINOSITY` set to `"dark"` to ensure better readability on light backgrounds.
  - Provide `COLOR_LUMINOSITY` as option argument on `randomColor` function call, that will ensure darker colors setup

- **Dynamic Color Change on New Quote Request:**
  - Ensured the color of the quote text and button changes with every new quote request.
  - Updated the color generation logic in `getNewQuote` to apply a new color for each request, ensuring that the user sees a fresh color with each quote.

- **API Request and Error Handling:**
  - The `getNewQuote` function now sets a new color before starting the API request.

- **LocalStorage:**
  - On page load or refresh, if a quote is stored in `localStorage`, set new color.

### Testing:
- Verified that the generated color is always readable by using dark luminosity settings.
- Ensured that the color changes with each new quote request.
- Ensure that new color is set when page is loaded or refreshed if quote is setted in `localStorage`.

**Related Issue:**
- Closes #18 